### PR TITLE
Fix size_score keys to match Table 1 specification exactly

### DIFF
--- a/src/metrics/calculator.py
+++ b/src/metrics/calculator.py
@@ -81,7 +81,8 @@ class MetricsCalculator:
                     # Provide default values on failure
                     if metric_name == 'size_score':
                         metrics[metric_name] = {
-                            "raspberry_pi_jetson_nano": 0.0,
+                            "raspberry_pi": 0.0,
+                            "jetson_nano": 0.0,
                             "desktop_pc": 0.5,
                             "aws_server": 1.0
                         }
@@ -109,7 +110,8 @@ class MetricsCalculator:
             "license": metrics.get("license", 0.0),
             "license_latency": metrics.get("license_latency", 1000),
             "size_score": metrics.get("size_score", {
-                "raspberry_pi_jetson_nano": 0.0,
+                "raspberry_pi": 0.0,
+                "jetson_nano": 0.0,
                 "desktop_pc": 0.5,
                 "aws_server": 1.0
             }),

--- a/src/metrics/size_metric.py
+++ b/src/metrics/size_metric.py
@@ -19,7 +19,8 @@ class SizeMetric:
         
         # Hardware constraints (in GB)
         self.hardware_limits = {
-            'raspberry_pi_jetson_nano': 1.0,    # Combined constraint for small devices
+            'raspberry_pi': 1.0,    # 1GB model constraint
+            'jetson_nano': 4.0,     # 4GB RAM typical
             'desktop_pc': 16.0,     # 16GB RAM typical
             'aws_server': 64.0      # Large instance
         }


### PR DESCRIPTION
- Reverted to separate keys: raspberry_pi, jetson_nano, desktop_pc, aws_server
- Table 1 specification shows 4 separate hardware types, not combined
- This should fix BERT Base Uncased Package Tests (0/13 -> 13/13)
- Output now matches Table 1 specification exactly as written